### PR TITLE
Property setters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,7 @@ cache: pip
 
 python:
   - 2.7
-  - 3.3
-  - 3.4
   - 3.5
-  - pypy
-  - pypy3
 
 install:
   - pip install pip setuptools --upgrade

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -26,3 +26,47 @@ def test_default_methods():
 
     with pytest.raises(NotImplementedError):
         mr(None)
+
+
+def test_set_properties():
+
+    """All of the MapReduce level configuration happens in properties, but
+    since the entire ``MapReduce.__init__()`` is handed over to the user,
+    each of these properties needs to have a getter _and_ setter.
+    """
+
+    # Collect all the public properties
+    props = []
+    for attr in dir(base.BaseMapReduce):
+        obj = getattr(base.BaseMapReduce, attr)
+        if not attr.startswith('_') and isinstance(obj, property):
+            props.append(attr)
+
+    mr = base.BaseMapReduce()
+    for p in props:
+
+        # Make sure the attribute isn't already set for some reason but
+        # cache the value so it can be replaced once this property is tested
+        original = getattr(mr, p)
+        assert original != 'whatever', \
+            "Property '{}' has already been set?".format(p)
+
+        # This calls the setter
+        try:
+            setattr(mr, p, 'whatever')
+
+        # The default error message isn't very helpful for debugging tests.
+        except AttributeError:
+            raise AttributeError(
+                "Can't set property '{}' on '{}'".format(
+                    p, mr.__class__.__name__))
+
+        assert getattr(mr, p) == 'whatever'
+
+        # Some properties default to other properties, for instance 'map_jobs'
+        # and 'reduce_jobs' both default to 'jobs'.  If 'jobs' is tested
+        # first then 'map_jobs' and 'reduce_jobs' will inherit its new
+        # value.  By explicitly resetting the property's value to the
+        # original state this test is a little more sensitive to human
+        # errors, like if 'jobs.setter' actually points to 'chunksize'.
+        setattr(mr, p, original)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,6 +4,7 @@
 import pytest
 
 from tinymr import base
+from tinymr import errors
 
 
 def test_not_implemented_methods():
@@ -70,3 +71,17 @@ def test_set_properties():
         # original state this test is a little more sensitive to human
         # errors, like if 'jobs.setter' actually points to 'chunksize'.
         setattr(mr, p, original)
+
+
+def test_closed():
+
+    """Can't use a closed task twice."""
+
+    mr = base.BaseMapReduce()
+    assert not mr.closed
+    mr.close()
+    assert mr.closed
+
+    with base.BaseMapReduce() as mr:
+        assert not mr.closed
+    assert mr.closed

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -274,3 +274,23 @@ def test_MemMapReduce_check_keys(wordcount, tiny_text, method_name):
 
     with pytest.raises(NameError):
         wc(tiny_text)
+
+
+def test_closed(wordcount):
+
+    """An instance of a task that has been closed should raise an exception
+    if it is used twice.
+    """
+
+    wc = wordcount()
+    assert not wc.closed
+    wc.close()
+    assert wc.closed
+    with pytest.raises(errors.ClosedTaskError):
+        wc('')
+
+    with wordcount() as wc:
+        assert not wc.closed
+    assert wc.closed
+    with pytest.raises(errors.ClosedTaskError):
+        wc('')

--- a/tinymr/_compat.py
+++ b/tinymr/_compat.py
@@ -5,9 +5,9 @@ import itertools as it
 import sys
 
 
-if sys.version_info.major == 2:
+if sys.version_info.major == 2:  # pragma: no cover
     zip = it.izip
     map = it.imap
-else:
+else:  # pragma: no cover
     zip = zip
     map = map

--- a/tinymr/base.py
+++ b/tinymr/base.py
@@ -93,6 +93,11 @@ class _MRInternal(object):
     #         return True
 
 
+def _ensure_context(p, *args, **kwargs):
+    raise Exception(dir(p))
+
+
+
 class BaseMapReduce(_MRInternal):
 
     """Base class for various MapReduce implementations."""
@@ -105,65 +110,109 @@ class BaseMapReduce(_MRInternal):
 
     @property
     def jobs(self):
-        return 1
+        return getattr(self, '_mr_jobs', 1)
+
+    @jobs.setter
+    def jobs(self, value):
+        self._mr_jobs = value
 
     @property
     def map_jobs(self):
-        return self.jobs
+        return getattr(self, '_mr_map_jobs', self.jobs)
+
+    @map_jobs.setter
+    def map_jobs(self, value):
+        self._mr_map_jobs = value
 
     @property
     def reduce_jobs(self):
-        return self.jobs
+        return getattr(self, '_mr_reduce_jobs', self.jobs)
+
+    @reduce_jobs.setter
+    def reduce_jobs(self, value):
+        self._mr_reduce_jobs = value
 
     @property
     def chunksize(self):
         """Default chunksize for map and reduce phases.  See ``map_chunksize``
         and ``reduce_chunksize``.
         """
-        return 1
+        return getattr(self, '_mr_chunksize', 1)
+
+    @chunksize.setter
+    def chunksize(self, value):
+        self._mr_chunksize = value
 
     @property
     def map_chunksize(self):
         """Pass items in groups of N to each map job when running with
         running with multiple jobs.
         """
-        return self.chunksize
+        return getattr(self, '_mr_map_chunksize', self.chunksize)
+
+    @map_chunksize.setter
+    def map_chunksize(self, value):
+        self._mr_map_chunksize = value
 
     @property
     def reduce_chunksize(self):
         """Pass items in groups of N to each reduce job when running with
         multiple jobs.
         """
-        return self.chunksize
+        return getattr(self, '_mr_reduce_chunksize', self.chunksize)
+
+    @reduce_chunksize.setter
+    def reduce_chunksize(self, value):
+        self._mr_reduce_chunksize = value
 
     @property
     def n_partition_keys(self):
         """Grab the first N keys for partitioning."""
-        return 1
+        return getattr(self, '_mr_n_partition_keys', 1)
+
+    @n_partition_keys.setter
+    def n_partition_keys(self, value):
+        self._mr_n_partition_keys = value
 
     @property
     def n_sort_keys(self):
         """Grab N keys after the partition keys when sorting."""
-        return 0
+        return getattr(self, '_mr_n_sort_keys', 0)
+
+    @n_sort_keys.setter
+    def n_sort_keys(self, value):
+        self._mr_n_sort_keys = value
 
     @property
     def threaded(self):
         """Use threads instead of processes when running multiple jobs."""
-        return False
+        return getattr(self, '_mr_threaded', False)
+
+    @threaded.setter
+    def threaded(self, value):
+        self._mr_threaded = value
 
     @property
     def threaded_map(self):
         """When running multiple jobs, use threads for the map phase instead
         of processes.
         """
-        return self.threaded
+        return getattr(self, '_mr_threaded_map', self.threaded)
+
+    @threaded_map.setter
+    def threaded_map(self, value):
+        self._mr_threaded_map = value
 
     @property
     def threaded_reduce(self):
         """When running multiple jobs, use threads for the reduce phase
         instead of processes.
         """
-        return self.threaded
+        return getattr(self, '_mr_threaded_reduce', self.threaded)
+
+    @threaded_reduce.setter
+    def threaded_reduce(self, value):
+        self._mr_threaded_reduce = value
 
     # @abc.abstractmethod
     # def combiner(self, key, values):

--- a/tinymr/base.py
+++ b/tinymr/base.py
@@ -6,8 +6,6 @@ from multiprocessing.dummy import Pool as DummyPool
 from multiprocessing.pool import Pool
 import operator as op
 
-from tinymr import errors
-
 
 class _MRInternal(object):
 
@@ -30,7 +28,7 @@ class _MRInternal(object):
             return 0
         else:
             return slice(0, self.n_partition_keys)
-    
+
     @property
     def _sort_key_idx(self):
         # Ensure a lack of sort keys is properly handled down the line by
@@ -91,11 +89,6 @@ class _MRInternal(object):
     #     # implemented and let the combine phase fail if its not
     #     except Exception:
     #         return True
-
-
-def _ensure_context(p, *args, **kwargs):
-    raise Exception(dir(p))
-
 
 
 class BaseMapReduce(_MRInternal):
@@ -295,5 +288,10 @@ class BaseMapReduce(_MRInternal):
     def close(self):
         """Only automatically called only when using the MapReduce task as a
         context manager.
+
+        Be sure to set ``self.closed = True`` when overriding this method,
+        otherwise a task can be used twice.  The assumption is that using an
+        instance of a task after  ``MapReduce.close()`` or
+        ``MapReduce.__exit__()`` is called will raise an exception.
         """
-        pass
+        self.closed = True

--- a/tinymr/base.py
+++ b/tinymr/base.py
@@ -214,6 +214,14 @@ class BaseMapReduce(_MRInternal):
     def threaded_reduce(self, value):
         self._mr_threaded_reduce = value
 
+    @property
+    def closed(self):
+        return getattr(self, '_mr_closed', False)
+
+    @closed.setter
+    def closed(self, value):
+        self._mr_closed = value
+
     # @abc.abstractmethod
     # def combiner(self, key, values):
     #     """Mini reduce operation for the data from one map operation.

--- a/tinymr/errors.py
+++ b/tinymr/errors.py
@@ -3,3 +3,7 @@
 
 class KeyCountError(KeyError):
     """The number of expected keys does not match the number of actual keys."""
+
+
+class ClosedTaskError(ValueError):
+    """Raised when attempting to use a closed MapReduce task twice."""

--- a/tinymr/memory.py
+++ b/tinymr/memory.py
@@ -28,6 +28,9 @@ class MemMapReduce(base.BaseMapReduce):
 
     def __call__(self, stream):
 
+        if self.closed:
+            raise errors.ClosedTaskError("Task is closed.")
+
         self.init_map()
 
         if self.map_jobs == 1:


### PR DESCRIPTION
So task configuration can be set in `__init__()` like:

```python
from tinymr.memory import MemMapReduce

class WordCount(MemMapReduce):
    
    def __init__(self, jobs=1):
        self.jobs = jobs
```

previously this raised an `AttributeError` complaining that the `jobs` property is not set-able.

Also introduces `MapReduce.closed` and better support for `MapReduce.close()`.